### PR TITLE
change generating TOC workflow

### DIFF
--- a/.github/workflows/toc.yml
+++ b/.github/workflows/toc.yml
@@ -1,30 +1,19 @@
 name: generate-toc
 
 on:
-  push:
-    paths:
-      - '*.md'
-      - 'documents/*.md'
-    branches:
-      - 'master'
+  pull_request:
+    types: [labeled]
 
 jobs:
-  # WIP でジョブがスキップされてもCIが失敗した扱いにならないようにするため
+  # ジョブがスキップされてもCIが失敗した扱いにならないようにするため
   skip:
     runs-on: ubuntu-latest
     steps:
       - run: echo "Skip job"
 
-  # WIP がコミットメッセージに含まれているとジョブを起動しない
-  before:
-    runs-on: ubuntu-latest
-    if: "! contains(github.event.head_commit.message, 'WIP')"
-    steps:
-      - run: echo "no WIP"
-
   generate-toc:
     runs-on: ubuntu-latest
-    needs: before
+    if: github.event.label.name == 'toc'
     steps:
       - uses: actions/checkout@v1
 
@@ -43,7 +32,12 @@ jobs:
           git add *.md documents/*.md
           git commit -m ":memo: [CI] update TOC"
 
+        # PR作成ブランチにPushする
+      - name: Set output
+        id: vars
+        run: echo ::set-output name=branch::${GITHUB_HEAD_REF}
       - name: Git push
         uses: ad-m/github-push-action@v0.5.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
+          branch: ${{ steps.vars.outputs.branch }}


### PR DESCRIPTION
* Pull requestの画面に対して `toc` という名前のラベルをつけるとCIを起動するように変更
* ラベルを外すときは起動しません
* `toc` 以外のラベルを付与した場合は、CIのVMは起動しますが、ジョブはスキップされます
* [こういう振る舞い](https://github.com/jiro4989/action-test/pull/4)をします
