### PR TITLE
CIを整備

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -42,7 +42,7 @@ jobs:
       with:
         path: ~/.nimble
         key: ${{ runner.os }}-nimble-${{ env.NIM_VERSION }}
-    - uses: jiro4989/setup-nim-action@v1.0.1
+    - uses: jiro4989/setup-nim-action@v1
       with:
         nim-version: ${{ env.NIM_VERSION }}
     - name: Build

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -57,6 +57,8 @@ jobs:
         nim-version: ${{ matrix.nim-version }}
     - name: Build
       run: nimble build -Y
+    - name: Install
+      run: nimble install -Y
 
   test-on-docker:
     runs-on: ubuntu-latest

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -1,6 +1,14 @@
 name: Build and test Nim
 
-on: [push, pull_request]
+on:
+  push:
+    paths-ignore:
+      - '*.md'
+      - 'documents/*'
+  pull_request:
+    paths-ignore:
+      - '*.md'
+      - 'documents/*'
 
 jobs:
   # WIP でジョブがスキップされてもCIが失敗した扱いにならないようにするため

--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -26,8 +26,10 @@ jobs:
           # - macOS-latest
           # Need sqlite3_64.dll
           # - windows-latest
-    env:
-      NIM_VERSION: 1.2.0
+        nim-version:
+          - 1.2.0
+          - 1.4.0
+          - stable
     steps:
     - uses: actions/checkout@v1
     - name: Cache choosenim
@@ -35,16 +37,16 @@ jobs:
       uses: actions/cache@v1
       with:
         path: ~/.choosenim
-        key: ${{ runner.os }}-choosenim-${{ env.NIM_VERSION }}
+        key: ${{ runner.os }}-choosenim-${{ matrix.nim-version }}
     - name: Cache nimble
       id: cache-nimble
       uses: actions/cache@v1
       with:
         path: ~/.nimble
-        key: ${{ runner.os }}-nimble-${{ env.NIM_VERSION }}
+        key: ${{ runner.os }}-nimble-${{ matrix.nim-version }}
     - uses: jiro4989/setup-nim-action@v1
       with:
-        nim-version: ${{ env.NIM_VERSION }}
+        nim-version: ${{ matrix.nim-version }}
     - name: Build
       run: nimble build -Y
 


### PR DESCRIPTION
- setup-nim-versionのバージョンを変更
- Nim 1.2.0, 1.4.0, stableをテストするように変更
- ドキュメントだけ更新されたときはCIを起動しないように変更
- `nimble install` のテストを追加