### PR TITLE
Add bash-completion for ducere

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *
 !*.*
 !*/
+!completions/bash/ducere
 
 # Created by https://www.gitignore.io/api/nim
 # Edit at https://www.gitignore.io/?templates=nim

--- a/completions/bash/ducere
+++ b/completions/bash/ducere
@@ -1,0 +1,23 @@
+# ducere(1) completion                                       -*- shell-script -*-
+
+_ducere_module() {
+	local cur prev cword
+	_get_comp_words_by_ref -n : cur prev cword
+
+  case "${cword}" in
+    1)
+      local subcmds="help new make serve build migrate"
+      COMPREPLY=($(compgen -W "${subcmds}" -- "${cur}"))
+      ;;
+    2)
+      case "${prev}" in
+        make)
+          local subcmds="config migration controller usecase model valueobject layout page"
+          COMPREPLY=($(compgen -W "${subcmds}" -- "${cur}"))
+          ;;
+      esac
+      ;;
+  esac
+}
+
+complete -F _ducere_module ducere

--- a/documents/en/ducere.md
+++ b/documents/en/ducere.md
@@ -5,25 +5,26 @@ Ducere command
 Table of Contents
 
 <!--ts-->
-   * [Ducere command](#ducere-command)
-      * [Introduction](#introduction)
-      * [Usages](#usages)
-         * [new](#new)
-         * [serve](#serve)
-         * [build](#build)
-         * [migrate](#migrate)
-         * [make](#make)
-            * [config](#config)
-            * [controller](#controller)
-            * [view](#view)
-            * [migration](#migration)
-            * [model](#model)
-               * [Create top level domain model(=aggregate)](#create-top-level-domain-modelaggregate)
-               * [Create child domain model in aggregate](#create-child-domain-model-in-aggregate)
-            * [usecase](#usecase)
-            * [value object](#value-object)
+* [Ducere command](#ducere-command)
+   * [Introduction](#introduction)
+   * [Usages](#usages)
+      * [new](#new)
+      * [serve](#serve)
+      * [build](#build)
+      * [migrate](#migrate)
+      * [make](#make)
+         * [config](#config)
+         * [controller](#controller)
+         * [view](#view)
+         * [migration](#migration)
+         * [model](#model)
+            * [Create top level domain model(=aggregate)](#create-top-level-domain-modelaggregate)
+            * [Create child domain model in aggregate](#create-child-domain-model-in-aggregate)
+         * [usecase](#usecase)
+         * [value object](#value-object)
+   * [Bash-completion](#bash-completion)
 
-<!-- Added by: root, at: Mon Apr 19 05:12:45 UTC 2021 -->
+<!-- Added by: root, at: Tue May  4 05:45:57 UTC 2021 -->
 
 <!--te-->
 

--- a/documents/en/ducere.md
+++ b/documents/en/ducere.md
@@ -273,3 +273,23 @@ ducere make valueobject {arg1} {arg2}
 ducere make valueobject UserName user
 >> add UserName in app/domain/models/user/user_value_objects.nim
 ```
+
+## Bash-completion
+
+Clone this repository if you want to use `bash-completion` for `ducere`.
+
+```sh
+git clone https://github.com/itsumura-h/nim-basolato /path/to/nim-basolato
+```
+
+And add this shell script to `~/.bashrc`.
+
+```sh
+source /path/to/nim-basolato/completions/bash/ducere
+```
+
+Or, copy completion file to directory.
+
+```sh
+sudo install -o root -g root -m 0644 /path/to/nim-basolato/completions/bash/ducere /usr/share/bash-completion/completions/ducere
+```

--- a/documents/ja/ducere.md
+++ b/documents/ja/ducere.md
@@ -5,25 +5,26 @@ Ducereコマンド
 コンテンツ
 
 <!--ts-->
-   * [Ducereコマンド](#ducereコマンド)
-      * [イントロダクション](#イントロダクション)
-      * [使い方](#使い方)
-         * [new](#new)
-         * [serve](#serve)
-         * [build](#build)
-         * [migrate](#migrate)
-         * [make](#make)
-            * [config](#config)
-            * [controller](#controller)
-            * [view](#view)
-            * [migration](#migration)
-            * [model](#model)
-               * [最上位のドメインモデル（＝集約）を作る](#最上位のドメインモデル集約を作る)
-               * [集約の子要素のドメインモデルを作る](#集約の子要素のドメインモデルを作る)
-            * [usecase](#usecase)
-            * [value object](#value-object)
+* [Ducereコマンド](#ducereコマンド)
+   * [イントロダクション](#イントロダクション)
+   * [使い方](#使い方)
+      * [new](#new)
+      * [serve](#serve)
+      * [build](#build)
+      * [migrate](#migrate)
+      * [make](#make)
+         * [config](#config)
+         * [controller](#controller)
+         * [view](#view)
+         * [migration](#migration)
+         * [model](#model)
+            * [最上位のドメインモデル（＝集約）を作る](#最上位のドメインモデル集約を作る)
+            * [集約の子要素のドメインモデルを作る](#集約の子要素のドメインモデルを作る)
+         * [usecase](#usecase)
+         * [value object](#value-object)
+   * [Bash-completion](#bash-completion)
 
-<!-- Added by: root, at: Mon Apr 19 05:13:58 UTC 2021 -->
+<!-- Added by: root, at: Tue May  4 05:46:14 UTC 2021 -->
 
 <!--te-->
 

--- a/documents/ja/ducere.md
+++ b/documents/ja/ducere.md
@@ -284,3 +284,24 @@ ducere make valueobject {引数1} {引数2}
 ducere make valueobject UserName user
 >> add UserName in app/domain/models/user/user_value_objects.nim
 ```
+
+## Bash-completion
+
+もし `ducere` でBashのタブ補完機能を使いたければ、この手順を実施してください。
+まず、このリポジトリを任意の場所に clone します。
+
+```sh
+git clone https://github.com/itsumura-h/nim-basolato /path/to/nim-basolato
+```
+
+次に、以下のシェルを `~/.bashrc` に追記します。
+
+```sh
+source /path/to/nim-basolato/completions/bash/ducere
+```
+
+あるいは、 `bash-completion` 用の所定の場所にファイルをコピーします。
+
+```sh
+sudo install -o root -g root -m 0644 /path/to/nim-basolato/completions/bash/ducere /usr/share/bash-completion/completions/ducere
+```


### PR DESCRIPTION
`ducere` コマンドを使う時に、サブコマンドをTABキーで補完できるようにしたかったので
`bash-completion` 用の completions ファイルを追加しました。

Bashの場合だけですが、設定ファイルを所定の場所に配置するか、設定をロードすればタブキーで補完されるようになります