### PR TITLE
bump major of actions/checkout

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -39,7 +39,7 @@ jobs:
           - 1.4.0
           - stable
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Cache choosenim
       id: cache-choosenim
       uses: actions/cache@v1
@@ -64,7 +64,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: before
     steps:
-    - uses: actions/checkout@v1
+    - uses: actions/checkout@v2
     - name: Test
       run: docker-compose run app sh /root/project/runTest.sh
     - name: Test multi-thread


### PR DESCRIPTION
- `actions/checkout` のバージョンを2系に上げました
- 2系の方がコミット数が多い場合に、より高速に git clone されます
  - これは `git clone --depth 1` と同様の振る舞いになるため、最新コミットだけとってくるため高速化されます
  - つまり、例えば過去のコミットログにアクセスするようなケースでは、別途オプションを設定する必要があります
  - 今回のCIにおいては問題ないはずです