### PR TITLE
chore: add 'set -eux' flag

### DIFF
--- a/runTest.sh
+++ b/runTest.sh
@@ -15,6 +15,7 @@
 
 # find tests/ -type f ! -name "*.*" -delete 2>/dev/null
 
+set -eux
 
 # run server
 nimble install -y
@@ -40,4 +41,4 @@ rm tests/server/session.db
 rm tests/server/session.db.bak
 rm -fr tests/server/logs/*
 rm .env .env.local
-find tests/ -type f ! -name "*.*" -delete 2>/dev/null
+find tests/ -type f ! -name "*.*" -delete 2> /dev/null


### PR DESCRIPTION
シェルスクリプトに `eux` フラグを追加しました。
これにより、途中のコマンドが失敗した場合に、GitHub ActionsのCIもコケるようになります。

フラグはそれぞれ以下の意味を持ちます。

| フラグ | 説明 |
| --- | --- |
| e | シェルスクリプトを実行した時に途中のコマンドが失敗するとそこでスクリプトを中断し、異常終了させる |
| u | 未定義変数を使用しようとした時にエラーを発生させる |
| x | 実行したコマンドを画面に出力する |

---

シェルスクリプトは `set` でフラグを設定しなかった場合、
最後に実行されたコマンドの終了コードがシェルスクリプトの終了コードとして評価されます。

どうやらどこかのタイミングでテストがコケるようになっていたようですが、
シェルスクリプトにフラグが設定されていなかったため、GitHub ActionsとしてはテストがPASSしてしまっています。

テストコードを直す方法については、僕は見当がつかないですが、
シェルスクリプトの方にフラグを追加して、テストがコケた場合に CI としてもコケるようにすることで、
テストがコケる様になったことに早期に気付けるようにだけしました。

