### PR TITLE
Docker上でのテストでベースイメージを指定できるように変更

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -64,8 +64,16 @@ jobs:
   test-on-docker:
     runs-on: ubuntu-latest
     needs: before
+    strategy:
+      matrix:
+        image-tag:
+          - 1.4.4-alpine
+          - 1.4.8-alpine
+          - 1.6.0-alpine
     steps:
     - uses: actions/checkout@v2
+    - name: Build docker image
+      run: docker-compose build --build-arg IMAGE_TAG=${{ matrix.image-tag }} app
     - name: Test
       run: docker-compose run app sh /root/project/runTest.sh
     - name: Test multi-thread

--- a/docker/nim/Dockerfile
+++ b/docker/nim/Dockerfile
@@ -1,4 +1,5 @@
-FROM nimlang/nim:1.4.4-alpine
+ARG IMAGE_TAG="1.4.4-alpine"
+FROM nimlang/nim:${IMAGE_TAG}
 
 RUN echo http://dl-cdn.alpinelinux.org/alpine/edge/testing >> /etc/apk/repositories
 RUN apk update && \

--- a/runTest.sh
+++ b/runTest.sh
@@ -17,6 +17,9 @@
 
 set -eux
 
+nim -v
+nimble -v
+
 # run server
 nimble install -y
 cd /root/project/tests/server


### PR DESCRIPTION
ベースイメージをCIから指定できるようにしました

変更に加えて、 `1.4.8` と `1.6.0` でもテストをするようにしました。

どうやら `1.6.0` だとテストがテストにコケるようになっていたみたいです