### PR TITLE
Change file modification detection method from timestamp to hash

### DIFF
--- a/.github/workflows/nim.yml
+++ b/.github/workflows/nim.yml
@@ -42,7 +42,7 @@ jobs:
     - name: Test
       run: |
         docker compose -f compose.test.yaml up -d
-        docker compose -f compose.test.yaml run basolato-test-ubuntu sh runTest.sh
+        docker compose -f compose.test.yaml run basolato-test-ubuntu bash runTest.sh
 
 
   # test-on-docker:

--- a/basolato.nimble
+++ b/basolato.nimble
@@ -22,7 +22,10 @@ requires "cligen >= 1.5.9"
 requires "redis >= 0.3.0"
 requires "sass >= 0.1.0"
 requires "nimcrypto >= 0.6.0"
-requires "checksums >= 0.1.0"
+
+when NimMajor == 2:
+  requires "checksums >= 0.1.0"
+
 
 import strformat, os
 

--- a/basolato.nimble
+++ b/basolato.nimble
@@ -22,6 +22,7 @@ requires "cligen >= 1.5.9"
 requires "redis >= 0.3.0"
 requires "sass >= 0.1.0"
 requires "nimcrypto >= 0.6.0"
+requires "checksums >= 0.1.0"
 
 import strformat, os
 

--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -1,5 +1,5 @@
 services:
-  basolato-test-redis:
+  redis:
     image: redis:alpine
     tty: true
 

--- a/compose.yaml
+++ b/compose.yaml
@@ -8,7 +8,7 @@ services:
     environment:
       - REDIS_HOSTS=local:redis:6379
     ports:
-      - '9001:8081'
+      - 8081:8081
     depends_on:
       - redis
 

--- a/runTest.sh
+++ b/runTest.sh
@@ -1,5 +1,7 @@
 set -eux
 
+trap finally EXIT
+
 nim -v
 nimble -v
 
@@ -16,15 +18,18 @@ touch server/session.db
 touch server/db.sqlite3
 cp server/.env ./
 rm -fr ./testresults
-testament p "test_*.nim" || true # do not exit on error
-testament p "*/test_*.nim" || true # do not exit on error
+testament p "test_*.nim"
+testament p "*/test_*.nim"
 
-# delete files
-pkill main
-rm server/main
-rm server/db.sqlite3
-rm server/session.db
-rm -fr logs
-rm -fr server/logs
-rm .env
-find ./ -type f ! -name "*.*" -delete 2> /dev/null
+function finally {
+  # delete files
+  pkill main
+  rm server/main
+  rm server/db.sqlite3
+  rm server/session.db
+  rm session.db
+  rm -fr logs
+  rm -fr server/logs
+  rm .env
+  find ./ -type f ! -name "*.*" -delete 2> /dev/null
+}

--- a/runTest.sh
+++ b/runTest.sh
@@ -2,6 +2,19 @@ set -eux
 
 trap finally EXIT
 
+function finally {
+  # delete files
+  pkill main
+  rm server/main
+  rm server/db.sqlite3
+  rm server/session.db
+  rm session.db
+  rm -fr logs
+  rm -fr server/logs
+  rm .env
+  find ./ -type f ! -name "*.*" -delete 2> /dev/null
+}
+
 nim -v
 nimble -v
 
@@ -20,16 +33,3 @@ cp server/.env ./
 rm -fr ./testresults
 testament p "test_*.nim"
 testament p "*/test_*.nim"
-
-function finally {
-  # delete files
-  pkill main
-  rm server/main
-  rm server/db.sqlite3
-  rm server/session.db
-  rm session.db
-  rm -fr logs
-  rm -fr server/logs
-  rm .env
-  find ./ -type f ! -name "*.*" -delete 2> /dev/null
-}

--- a/src/basolato/cli/functions/serveImpl.nim
+++ b/src/basolato/cli/functions/serveImpl.nim
@@ -5,8 +5,11 @@ import std/strutils
 import std/strformat
 import std/tables
 import std/terminal
-import checksums/md5
 
+when NimMajor == 2:
+  import checksums/md5
+elif NimMajor == 1:
+  import std/md5
 
 let
   sleepTime = 2

--- a/src/basolato/cli/functions/serveImpl.nim
+++ b/src/basolato/cli/functions/serveImpl.nim
@@ -5,7 +5,7 @@ import std/strutils
 import std/strformat
 import std/tables
 import std/terminal
-import std/times
+import checksums/md5
 
 
 let
@@ -13,7 +13,7 @@ let
   currentDir = getCurrentDir()
 
 var
-  files: Table[string, Time]
+  fileList: Table[string, string] # path, hash
   isModified = false
   p: Process
   pid = 0
@@ -73,25 +73,25 @@ proc serve*(port=8000, force=false, httpbeast=false, httpx=false) =
     sleep sleepTime * 1000
     for f in walkDirRec(currentDir, {pcFile}):
       if f.find(re"(\.nim|\.nims|\.html)$") > -1:
-        var modTime: Time
+        var fileHash: string
         try:
-          modTime = getFileInfo(f).lastWriteTime
+          fileHash = readFile(f).getMD5()
         except:
           # file is deleted
-          files.del(f)
+          fileList.del(f)
           isModified = true
-          break
+          continue
 
-        if not files.hasKey(f):
-          files[f] = modTime
+        if not fileList.hasKey(f):
+          fileList[f] = fileHash
           # debugEcho &"Skip {f} because of first checking"
           continue
-        if files[f] == modTime:
+        if fileList[f] == fileHash:
           # debugEcho &"Skip {f} because of the file has not modified"
           continue
         # modified
         isModified = true
-        files[f] = modTime
+        fileList = initTable[string, string]()
         break
 
     if isModified:

--- a/src/basolato/core/libservers/std/request.nim
+++ b/src/basolato/core/libservers/std/request.nim
@@ -1,4 +1,5 @@
-import std/asynchttpserver; export asynchttpserver
+import std/asynchttpserver
+export asynchttpserver
 import std/asyncnet
 import std/net
 import std/strutils

--- a/tests/test_request_params.nim
+++ b/tests/test_request_params.nim
@@ -2,12 +2,13 @@ discard """
   cmd: "nim c -d:test $file"
   matrix: "; -d:httpbeast"
 """
+# nim c -d:test -r test_request_params.nim
 
 import std/unittest
 import std/json
 import ../src/basolato/core/params
 
-when defined(htttpbeast):
+when defined(httpbeast):
   include ../src/basolato/core/libservers/nostd/request
 else:
   include ../src/basolato/core/libservers/std/request


### PR DESCRIPTION
- Add checksums >= 0.1.0 to basolato.nimble
- Fix port mapping in compose.yaml
- Modify src/basolato/cli/functions/serveImpl.nim
  - Import checksums/md5 instead of std/times
  - Use MD5 hash value instead of file timestamp to detect file changes
  - If any file is modified, reset fileList and recheck all files