### PR TITLE
feat: add support for raw variable display in templates

### DIFF
--- a/documents/en/view.md
+++ b/documents/en/view.md
@@ -68,6 +68,16 @@ proc view():Component =
   """
 ```
 
+### call variable without escape
+`$(msg|raw)` can display variable without escape.
+
+```nim
+proc view():Component =
+  let msg = "<p>Hello</p>"
+  tmpl"""
+    <div>$(msg|raw)</div>
+  """
+```
 
 ### call function
 `$()` can call function too.

--- a/documents/ja/view.md
+++ b/documents/ja/view.md
@@ -67,6 +67,17 @@ proc view():Component =
   """
 ```
 
+### エスケープしないで変数を表示する
+`$(msg|raw)`を使うことで、エスケープしないで変数を表示することができます。
+
+```nim
+proc view():Component =
+  let msg = "<p>Hello</p>"
+  tmpl"""
+    <div>$(msg|raw)</div>
+  """
+```
+
 ### 関数呼び出し
 `$()`は関数も呼ぶことができます
 

--- a/src/basolato/core/templates.nim
+++ b/src/basolato/core/templates.nim
@@ -330,7 +330,13 @@ macro tmpl*(html: untyped): untyped =
     of displayVariableBlock:
       var (resPoint, resStr) = findNimVariableBlock(html, point)
       resStr = resStr.strip()
-      resStr = &"result.add(toString(({resStr})))"
+
+      if resStr.endsWith("|raw"):
+        let varName = resStr.split("|")[0].strip()
+        resStr = &"result.add(({varName}))"
+      else:
+        resStr = &"result.add(toString(({resStr})))"
+
       resStr = reindent(resStr, indentLevel)
       body.add(resStr & "\n")
       point = resPoint

--- a/tests/test_templates.nim
+++ b/tests/test_templates.nim
@@ -158,6 +158,17 @@ suite("parseTemplate"):
     check $res == "<p>Hello, world!</p>"
 
 
+  test("display nim variable without escape"):
+    let msg = "<p>Hello, world!</p>"
+    proc view():Component =
+      tmpl"""
+        <div>$(msg|raw)</div>
+      """
+    let res = view()
+    echo res
+    check $res == "<div><p>Hello, world!</p></div>"
+
+
   test("call nim funcion"):
     proc fn():string = return "hello func"
     proc view():Component =


### PR DESCRIPTION
- Implemented the ability to display variables without escaping using the `$(var|raw)` syntax in the `tmpl` macro.
- Updated the `tmpl` macro to check for the `|raw` suffix and handle variable addition accordingly.
- Added test cases to verify the new functionality for displaying raw HTML content.